### PR TITLE
fix typo in License file

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-AL PUBLIC LICENSE
+GNU GENERAL PUBLIC LICENSE
 ==========================
 
 Version 3, 29 June 2007


### PR DESCRIPTION
fixed typo: AL PUBLIC LICENSE => GNU GENERAL PUBLIC LICENSE